### PR TITLE
Update to Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test generating build number on Ubuntu
       uses: ./
       with:
@@ -32,7 +32,7 @@ jobs:
     runs-on: windows-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test generating build number on Windows
       uses: ./
       with:

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Build Tag Number'
 description: 'Sequential build numbers for workflow runs based on Git tag'
 author: 'Onyx Mueller'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
 inputs:
   token:


### PR DESCRIPTION
Node 16 has reached its end of life. This updates source and test workflows to Node 20. Thanks to @Wolf2323 for nudging me to get this done.

Reference: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/