### PR TITLE
chore: upgrade node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Build Tag Number'
 description: 'Sequential build numbers for workflow runs based on Git tag'
 author: 'Onyx Mueller'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'main.js'
 inputs:
   token:


### PR DESCRIPTION
Node20 will reach end-of-life (EOL) in April of 2026. This updates the source to Node 24.

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/