### PR TITLE
ci: update checkout action in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Test generating build number on Ubuntu
       uses: ./
       with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: windows-latest
     permissions: write-all
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Test generating build number on Windows
       uses: ./
       with:


### PR DESCRIPTION
This updates the `checkout` actions in the `test` workflow from v4 to v6.