### PR TITLE
Fixed “too many tags” conflict with "delete_previous_tag: false" option

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,7 +97,7 @@ function main() {
             nrTags = result.filter(d => d.ref.match(regex));
             
             const MAX_OLD_NUMBERS = 5; //One or two ref deletes might fail, but if we have lots then there's something wrong!
-            if (nrTags.length > MAX_OLD_NUMBERS) {
+            if (deletePreviousTag && nrTags.length > MAX_OLD_NUMBERS) {
                 fail(`ERROR: Too many ${prefix}build-number- refs in repository, found ${nrTags.length}, expected only 1. Check your tags!`);
             }
             


### PR DESCRIPTION
The *too many tags* error message makes a lot of sense when previous tags are being deleted (the default). When a user specifies the `delete_previous_tag: false` option though, they typically want the previous tags left intact for historical purposes, so the error makes less sense.

This request includes a one-line change, and only affects the action when `delete_previous_tag: false` is configured; otherwise, the *too many* tags situation is checked just as before.