### PR TITLE
test: add unit test harness and tests for existing behavior

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+    - name: Run Node unit tests
+      run: node --test
+
   # test action on Ubuntu
   test-ubuntu:
     runs-on: ubuntu-latest

--- a/tests/helpers/child_runner.js
+++ b/tests/helpers/child_runner.js
@@ -111,8 +111,11 @@ const baseEnv = {
     GITHUB_OUTPUT: '/tmp/gh_output_stub',
     GITHUB_ENV: '/tmp/gh_env_stub',
 };
+// GitHub Actions runners pre-populate GITHUB_OUTPUT, GITHUB_ENV,
+// GITHUB_REPOSITORY, and GITHUB_SHA — force-overwrite so the action writes
+// to our stub paths instead of the runner's real ones.
 for (const k of Object.keys(baseEnv)) {
-    if (process.env[k] === undefined) process.env[k] = baseEnv[k];
+    process.env[k] = baseEnv[k];
 }
 for (const [k, v] of Object.entries(env)) {
     if (v === null) delete process.env[k];

--- a/tests/helpers/child_runner.js
+++ b/tests/helpers/child_runner.js
@@ -1,0 +1,153 @@
+'use strict';
+
+// Runs inside fork(). Reads JSON config from argv[2], installs https + fs
+// stubs, then requires the action's main.js. Emits a JSON summary line to
+// stdout before exiting so the parent can assert on behavior.
+
+const Module = require('module');
+const realFs = require('fs');
+
+const opts = JSON.parse(process.argv[2]);
+const {
+    actionMain,
+    tags = 0,
+    refsStatus = 200,
+    createStatus = 201,
+    deleteStatus = 204,
+    inputs = {},
+    env = {},
+    existingBuildNumberFile = null,
+} = opts;
+
+let exitCode = null;
+const realExit = process.exit;
+process.exit = (code) => {
+    if (exitCode === null) exitCode = code;
+    throw new Error(`__STUB_EXIT_${code}__`);
+};
+process.on('uncaughtException', (e) => {
+    if (!String(e && e.message).startsWith('__STUB_EXIT_')) {
+        console.error('UNEXPECTED_ERROR:', (e && e.stack) || e);
+        if (exitCode === null) exitCode = 2;
+    }
+});
+
+const httpCalls = [];
+
+function buildRefs(prefix, n) {
+    const refs = [];
+    for (let i = 1; i <= n; i++) {
+        refs.push({
+            ref: `refs/tags/${prefix}build-number-${i}`,
+            object: { sha: 'deadbeef' },
+        });
+    }
+    return refs;
+}
+
+const stubHttps = {
+    request(options, callback) {
+        const method = options.method;
+        const reqPath = options.path;
+        const call = { method, path: reqPath };
+        httpCalls.push(call);
+        process.nextTick(() => {
+            let status;
+            let body;
+            if (method === 'GET') {
+                status = refsStatus;
+                if (refsStatus === 200) {
+                    const prefix = inputs.prefix ? `${inputs.prefix}-` : '';
+                    body = Buffer.from(JSON.stringify(buildRefs(prefix, tags)));
+                } else {
+                    body = Buffer.from(JSON.stringify({ message: 'Not Found' }));
+                }
+            } else if (method === 'POST') {
+                status = createStatus;
+                body = Buffer.from(JSON.stringify({ ok: true }));
+            } else if (method === 'DELETE') {
+                status = deleteStatus;
+                body = Buffer.alloc(0);
+            } else {
+                status = 500;
+                body = Buffer.alloc(0);
+            }
+            const res = {
+                statusCode: status,
+                headers: {},
+                on(event, fn) {
+                    if (event === 'data' && body.length > 0) fn(body);
+                    if (event === 'end') fn();
+                },
+            };
+            callback(res);
+        });
+        return { on() {}, write(b) { call.body = b.toString(); }, end() {} };
+    },
+};
+
+const writes = {};
+const stubFs = Object.create(realFs);
+stubFs.existsSync = (p) => p === 'BUILD_NUMBER/BUILD_NUMBER' && existingBuildNumberFile !== null;
+stubFs.readFileSync = (p, ...rest) => {
+    if (p === 'BUILD_NUMBER/BUILD_NUMBER' && existingBuildNumberFile !== null) {
+        return Buffer.from(String(existingBuildNumberFile));
+    }
+    return realFs.readFileSync(p, ...rest);
+};
+stubFs.writeFileSync = (p, data) => { writes[p] = data.toString(); };
+
+const origRequire = Module.prototype.require;
+Module.prototype.require = function (id) {
+    if (id === 'https') return stubHttps;
+    if (id === 'fs') return stubFs;
+    return origRequire.apply(this, arguments);
+};
+
+const baseEnv = {
+    INPUT_TOKEN: 'fake-token',
+    GITHUB_REPOSITORY: 'test-owner/test-repo',
+    GITHUB_SHA: 'cafebabe',
+    GITHUB_OUTPUT: '/tmp/gh_output_stub',
+    GITHUB_ENV: '/tmp/gh_env_stub',
+};
+for (const k of Object.keys(baseEnv)) {
+    if (process.env[k] === undefined) process.env[k] = baseEnv[k];
+}
+for (const [k, v] of Object.entries(env)) {
+    if (v === null) delete process.env[k];
+    else process.env[k] = v;
+}
+if (inputs.token !== undefined) process.env.INPUT_TOKEN = inputs.token;
+if (inputs.prefix !== undefined) process.env.INPUT_PREFIX = inputs.prefix;
+if (inputs.delete_previous_tag !== undefined) {
+    process.env.INPUT_DELETE_PREVIOUS_TAG = String(inputs.delete_previous_tag);
+}
+
+try {
+    require(actionMain);
+} catch (e) {
+    if (!String(e && e.message).startsWith('__STUB_EXIT_')) {
+        console.error('UNEXPECTED_ERROR:', (e && e.stack) || e);
+        if (exitCode === null) exitCode = 2;
+    }
+}
+
+function parseKV(s, key) {
+    if (!s) return null;
+    const m = s.match(new RegExp(`${key}=(\\S+)`));
+    return m ? parseInt(m[1], 10) : null;
+}
+
+setTimeout(() => {
+    const summary = {
+        exit_code: exitCode,
+        http_calls: httpCalls,
+        writes,
+        build_number: parseKV(writes['/tmp/gh_output_stub'], 'build_number'),
+        env_build_number: parseKV(writes['/tmp/gh_env_stub'], 'BUILD_NUMBER'),
+    };
+    process.stdout.write('\n' + JSON.stringify(summary) + '\n', () => {
+        realExit.call(process, 0);
+    });
+}, 40);

--- a/tests/helpers/run_action.js
+++ b/tests/helpers/run_action.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const path = require('path');
+const { fork } = require('child_process');
+
+const ACTION_MAIN = path.resolve(__dirname, '..', '..', 'main.js');
+const CHILD = path.resolve(__dirname, 'child_runner.js');
+
+function runAction(opts = {}) {
+    return new Promise((resolve, reject) => {
+        const payload = JSON.stringify({ actionMain: ACTION_MAIN, ...opts });
+        const child = fork(CHILD, [payload], {
+            stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+            env: { ...process.env, NODE_OPTIONS: '' },
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => { stdout += d.toString(); });
+        child.stderr.on('data', (d) => { stderr += d.toString(); });
+        child.on('error', reject);
+        child.on('exit', () => {
+            const lines = stdout.trimEnd().split('\n');
+            const last = lines[lines.length - 1];
+            try {
+                const summary = JSON.parse(last);
+                summary.stdout = stdout;
+                summary.stderr = stderr;
+                resolve(summary);
+            } catch (e) {
+                reject(new Error(
+                    `Could not parse child summary as JSON.\n` +
+                    `stdout:\n${stdout}\nstderr:\n${stderr}`
+                ));
+            }
+        });
+    });
+}
+
+module.exports = { runAction };

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { runAction } = require('./helpers/run_action');
+
+test('no existing tags (404): starts at build number 1 and creates new ref', async () => {
+    const r = await runAction({ refsStatus: 404 });
+    assert.equal(r.exit_code, null);
+    assert.equal(r.build_number, 1);
+    assert.equal(r.env_build_number, 1);
+    const posts = r.http_calls.filter((c) => c.method === 'POST');
+    assert.equal(posts.length, 1);
+    assert.ok(posts[0].body.includes('refs/tags/build-number-1'));
+    const deletes = r.http_calls.filter((c) => c.method === 'DELETE');
+    assert.equal(deletes.length, 0);
+});
+
+test('existing tags with default delete behavior: increments and deletes old refs', async () => {
+    const r = await runAction({ tags: 3 });
+    assert.equal(r.exit_code, null);
+    assert.equal(r.build_number, 4);
+    const posts = r.http_calls.filter((c) => c.method === 'POST');
+    assert.equal(posts.length, 1);
+    assert.ok(posts[0].body.includes('refs/tags/build-number-4'));
+    const deletes = r.http_calls.filter((c) => c.method === 'DELETE');
+    assert.equal(deletes.length, 3);
+});
+
+test('delete_previous_tag=false: increments without deleting old refs', async () => {
+    const r = await runAction({ tags: 3, inputs: { delete_previous_tag: false } });
+    assert.equal(r.exit_code, null);
+    assert.equal(r.build_number, 4);
+    const deletes = r.http_calls.filter((c) => c.method === 'DELETE');
+    assert.equal(deletes.length, 0);
+});
+
+test('prefix input is applied to the created ref', async () => {
+    const r = await runAction({ refsStatus: 404, inputs: { prefix: 'v' } });
+    assert.equal(r.exit_code, null);
+    const get = r.http_calls.find((c) => c.method === 'GET');
+    assert.ok(get.path.includes('/refs/tags/v-build-number-'));
+    const post = r.http_calls.find((c) => c.method === 'POST');
+    assert.ok(post.body.includes('refs/tags/v-build-number-1'));
+});
+
+test('missing INPUT_TOKEN fails fast with exit 1', async () => {
+    const r = await runAction({ env: { INPUT_TOKEN: null } });
+    assert.equal(r.exit_code, 1);
+    assert.equal(r.http_calls.length, 0);
+});
+
+test('missing GITHUB_REPOSITORY fails fast with exit 1', async () => {
+    const r = await runAction({ env: { GITHUB_REPOSITORY: null } });
+    assert.equal(r.exit_code, 1);
+    assert.equal(r.http_calls.length, 0);
+});
+
+test('missing GITHUB_SHA fails fast with exit 1', async () => {
+    const r = await runAction({ env: { GITHUB_SHA: null } });
+    assert.equal(r.exit_code, 1);
+    assert.equal(r.http_calls.length, 0);
+});
+
+test('cached BUILD_NUMBER file short-circuits API calls', async () => {
+    const r = await runAction({ existingBuildNumberFile: '42' });
+    assert.equal(r.exit_code, null);
+    assert.equal(r.build_number, 42);
+    assert.equal(r.env_build_number, 42);
+    assert.equal(r.http_calls.length, 0);
+});
+
+test('too many tags with delete_previous_tag=true fails with exit 1', async () => {
+    const r = await runAction({ tags: 6 });
+    assert.equal(r.exit_code, 1);
+    const posts = r.http_calls.filter((c) => c.method === 'POST');
+    assert.equal(posts.length, 0, 'should bail before creating a new ref');
+});


### PR DESCRIPTION
## Summary
Adds a zero-dependency unit-test suite for the action. Leans into Node's built-in test runner (`node --test`) and a small hand-rolled stub of `https` + `fs`.

- `tests/helpers/run_action.js` + `tests/helpers/child_runner.js` — fork `main.js` in a child process, stub `https.request` (configurable status codes, recorded calls) and `fs` writes, capture the action's behavior into a structured summary.
- `tests/main.test.js` — 9 tests covering existing behavior:
  - 404 on tag lookup → starts at build number 1
  - existing tags with default `delete_previous_tag` → increments and DELETEs old refs
  - `delete_previous_tag: false` → increments, no DELETEs
  - `prefix` input flows into both the GET path and the new ref
  - missing `INPUT_TOKEN` / `GITHUB_REPOSITORY` / `GITHUB_SHA` each exit 1 before any HTTP
  - cached `BUILD_NUMBER` file short-circuits API calls
  - too-many-tags safety net (>5 tags + delete on) exits 1
- `.github/workflows/test.yml` — new `unit-tests` job runs `node --test` on `node24` (matches `action.yml`).

All 9 tests pass locally against the current `main.js`. Runs in <1s.

## Test plan
- [x] CI `unit-tests` job is green
- [x] CI existing `test-ubuntu` / `test-windows` jobs still pass (no change to action behavior)
- [x] `node --test` produces 9 passing tests locally