### PR TITLE
test: add failing test for too_many_tags with delete_previous_tag false

### DIFF
--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -76,3 +76,14 @@ test('too many tags with delete_previous_tag=true fails with exit 1', async () =
     const posts = r.http_calls.filter((c) => c.method === 'POST');
     assert.equal(posts.length, 0, 'should bail before creating a new ref');
 });
+
+// When the user has explicitly set delete_previous_tag=false, build-number
+// refs are expected to accumulate beyond the safety threshold of 5. The
+// action must not treat that as an error. Fix: PR #21.
+test('too many tags with delete_previous_tag=false does NOT fail', async () => {
+    const r = await runAction({ tags: 6, inputs: { delete_previous_tag: false } });
+    assert.equal(r.exit_code, null, 'action should not fail when user opted out of deletion');
+    assert.equal(r.build_number, 7);
+    const deletes = r.http_calls.filter((c) => c.method === 'DELETE');
+    assert.equal(deletes.length, 0, 'no refs should be deleted');
+});


### PR DESCRIPTION
## Summary
Adds one unit test that demonstrates the bug fixed by #21. With current `main.js` on `main`, this test **fails** (action exits 1 instead of producing a build number). With #21 applied, it passes — verified locally by patching `main.js` with #21's diff and rerunning the suite.

The bug: when a user opts out of tag deletion (`delete_previous_tag: false`), build-number refs naturally accumulate. The "Too many ... refs" safety net at `main.js:100` fires once 6 tags are present, blocking the workflow even though the accumulation is intentional.

## Base / merge order
- This PR is stacked on #22 (test harness + existing-behavior tests). Base will flip to `main` once #22 lands.
- CI on this PR is expected to be **red** until #21 merges — the red `unit-tests` job is the demonstration of the bug.

## Local verification
| `main.js` source                | Result of new test         |
|---------------------------------|----------------------------|
| current `main` (no fix)         | ✖ `exit_code 1 !== null`   |
| PR #21's patched `main.js`      | ✔ pass (build_number = 7)  |

## Test plan
- [ ] CI `unit-tests` job on this PR is red, failing only on `too many tags with delete_previous_tag=false does NOT fail`
- [ ] After #21 merges into `main` and this branch is rebased, CI turns green