### PR TITLE
add annotated tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ jobs:
     - name: Generate build number
       uses: onyxmueller/build-tag-number@v1
       with:
-        token: ${{secrets.github_token}}        
+        token: ${{secrets.github_token}}
     - name: Print new build number
       run: echo "Build number is $BUILD_NUMBER"
       # Or, if you're on Windows: echo "Build number is ${env:BUILD_NUMBER}"
@@ -29,8 +29,8 @@ jobs:
       id: buildnumber
       uses: onyxmueller/build-tag-number@v1
       with:
-        token: ${{secrets.github_token}}        
-    
+        token: ${{secrets.github_token}}
+
     # Now you can pass ${{ steps.buildnumber.outputs.build_number }} to the next steps.
     - name: Another step as an example
       uses: actions/hello-world-docker-action@v1
@@ -56,7 +56,7 @@ jobs:
       uses: onyxmueller/build-tag-number@v1
       with:
         token: ${{secrets.github_token}}
-          
+
   job2:
     needs: job1
     runs-on: ubuntu-latest
@@ -80,7 +80,7 @@ and then your next build number will be 501. The action will always delete older
 
 ## Generating multiple independent build numbers
 
-Sometimes you may have more than one project to build in one repository. For example, you may have a client and a server in the same GitHub repository that you would like to generate independent build numbers for. Another example is you have two Dockerfiles in one repo and you'd like to version each of the built images with their own numbers.  
+Sometimes you may have more than one project to build in one repository. For example, you may have a client and a server in the same GitHub repository that you would like to generate independent build numbers for. Another example is you have two Dockerfiles in one repo and you'd like to version each of the built images with their own numbers.
 To do this, use the `prefix` key, like so:
 
 ```yaml
@@ -111,9 +111,31 @@ jobs:
     - name: Generate build number
       uses: onyxmueller/build-tag-number@v1
       with:
-        token: ${{secrets.github_token}}        
+        token: ${{secrets.github_token}}
         delete_previous_tag: false
 ```
+
+### Optional: Use *annotated* tags
+By default, the action uses *lightweight* tags. See [Git Basics - Tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging) for usages and the difference between
+*lightweight* and *annotated* tags. To use *annotated* tags, set `annotated_tag: true`:
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - name: Generate build number
+      uses: onyxmueller/build-tag-number@v1
+      with:
+        token: ${{secrets.github_token}}
+        annotated_tag: true
+```
+
+If desired, this option can be combined with `delete_previous_tag: false`. Note if you get a `Status: 403` error when using *annotated* tags, that likely means
+your project doesn't have the appropriate permissions to create the tag (annotated tags require write permission). One way to resolve this is by adding the
+`write` permission to your YAML file, as shown in the example above.
 
 ## Branches and build numbers
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   delete_previous_tag:
     description: 'If set to false, previous build number tags will not be deleted (default: true)'
     required: false
+  annotated_tag:
+    description: 'If set to true, use an annotated tag rather than a lightweight tag (default: false)'
+    required: false
 
 outputs:
   build_number:

--- a/main.js
+++ b/main.js
@@ -10,11 +10,11 @@ function fail(message, exitCode=1) {
 }
 
 function request(method, path, data, callback) {
-    
+
     try {
         if (data) {
             data = JSON.stringify(data);
-        }  
+        }
         const options = {
             hostname: 'api.github.com',
             port: 443,
@@ -29,7 +29,7 @@ function request(method, path, data, callback) {
             }
         }
         const req = https.request(options, res => {
-    
+
             let chunks = [];
             res.on('data', d => chunks.push(d));
             res.on('end', () => {
@@ -46,10 +46,10 @@ function request(method, path, data, callback) {
                     callback(null, res.statusCode, buffer.length > 0 ? JSON.parse(buffer) : null);
                 }
             });
-    
+
             req.on('error', err => callback(err));
         });
-    
+
         if (data) {
             req.write(data);
         }
@@ -65,6 +65,7 @@ function main() {
     const path = 'BUILD_NUMBER/BUILD_NUMBER';
     const prefix = env.INPUT_PREFIX ? `${env.INPUT_PREFIX}-` : '';
     const deletePreviousTag = env.INPUT_DELETE_PREVIOUS_TAG !== 'false';
+    const annotatedTag = env.INPUT_ANNOTATED_TAG === 'true';
 
     //See if we've already generated the build number and are in later steps...
     if (fs.existsSync(path)) {
@@ -75,7 +76,7 @@ function main() {
         fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${buildNumber}`);
         return;
     }
-    
+
     //Some sanity checking:
     for (let varName of ['INPUT_TOKEN', 'GITHUB_REPOSITORY', 'GITHUB_SHA']) {
         if (!env[varName]) {
@@ -84,9 +85,9 @@ function main() {
     }
 
     request('GET', `/repos/${env.GITHUB_REPOSITORY}/git/refs/tags/${prefix}build-number-`, null, (err, status, result) => {
-    
+
         let nextBuildNumber, nrTags;
-    
+
         if (status === 404) {
             console.log('No build-number ref available, starting at 1.');
             nextBuildNumber = 1;
@@ -95,18 +96,18 @@ function main() {
             const regexString = `/${prefix}build-number-(\\d+)$`;
             const regex = new RegExp(regexString);
             nrTags = result.filter(d => d.ref.match(regex));
-            
+
             const MAX_OLD_NUMBERS = 5; //One or two ref deletes might fail, but if we have lots then there's something wrong!
             if (deletePreviousTag && nrTags.length > MAX_OLD_NUMBERS) {
                 fail(`ERROR: Too many ${prefix}build-number- refs in repository, found ${nrTags.length}, expected only 1. Check your tags!`);
             }
-            
+
             //Existing build numbers:
             let nrs = nrTags.map(t => parseInt(t.ref.match(/-(\d+)$/)[1]));
-    
+
             let currentBuildNumber = Math.max(...nrs);
             console.log(`Last build nr was ${currentBuildNumber}.`);
-    
+
             nextBuildNumber = currentBuildNumber + 1;
             console.log(`Updating build counter to ${nextBuildNumber}...`);
         } else {
@@ -114,50 +115,83 @@ function main() {
                 fail(`Failed to get refs. Error: ${err}, status: ${status}`);
             } else {
                 fail(`Getting build-number refs failed with http status ${status}, error: ${JSON.stringify(result)}`);
-            } 
+            }
         }
 
-        let newRefData = {
-            ref:`refs/tags/${prefix}build-number-${nextBuildNumber}`, 
-            sha: env.GITHUB_SHA
-        };
-    
-        request('POST', `/repos/${env.GITHUB_REPOSITORY}/git/refs`, newRefData, (err, status, result) => {
-            if (status !== 201 || err) {
-                fail(`Failed to create new build-number ref. Status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
-            }
+        if (annotatedTag) {
+            let tagName = `${prefix}build-number-${nextBuildNumber}`;
 
-            console.log(`Successfully updated build number to ${nextBuildNumber}`);
-            
-            //Setting the output and a environment variable to new build number...
-            fs.writeFileSync(process.env.GITHUB_OUTPUT, `build_number=${nextBuildNumber}`);
-            fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${nextBuildNumber}`);
- 
-            //Save to file so it can be used for next jobs...
-            fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());
-            
-            //Cleanup
-            if (nrTags && deletePreviousTag) {
-                console.log(`Deleting ${nrTags.length} older build counters...`);
-            
-                for (let nrTag of nrTags) {
-                    request('DELETE', `/repos/${env.GITHUB_REPOSITORY}/git/${nrTag.ref}`, null, (err, status, result) => {
-                        if (status !== 204 || err) {
-                            console.warn(`Failed to delete ref ${nrTag.ref}, status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
-                        } else {
-                            console.log(`Deleted ${nrTag.ref}`);
-                        }
-                    });
+            let newTagData = {
+                tag: tagName,
+                message: `Build number ${nextBuildNumber}`,
+                object: env.GITHUB_SHA,
+                type: 'commit',
+                tagger: {
+                    name: 'github-actions[bot]',
+                    email: 'github-actions[bot]@users.noreply.github.com',
                 }
-            } else if (nrTags && !deletePreviousTag) {
-                console.log('Skipping deletion of previous build-number tags as requested.');
-            }
+            };
 
-        });
+            request('POST', `/repos/${env.GITHUB_REPOSITORY}/git/tags`, newTagData, (err, status, result) => {
+                if (status !== 201 || err) {
+                    fail(`Failed to create annotated tag object. Status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
+                    return;
+                }
+
+                let tagSha = result.sha; // SHA of the newly-created tag object
+
+                let newRefData = {
+                    ref: `refs/tags/${tagName}`,
+                    sha: tagSha
+                };
+
+                request('POST', `/repos/${env.GITHUB_REPOSITORY}/git/refs`, newRefData, (err, status, result) => {
+                    if (status !== 201 || err) {
+                        fail(`Failed to create new build-number ref for annotated tag. Status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
+                        return;
+                    }
+
+                });
+            });
+        } else {
+            let newRefData = {
+                ref:`refs/tags/${prefix}build-number-${nextBuildNumber}`,
+                sha: env.GITHUB_SHA
+            };
+
+            request('POST', `/repos/${env.GITHUB_REPOSITORY}/git/refs`, newRefData, (err, status, result) => {
+                if (status !== 201 || err) {
+                    fail(`Failed to create new build-number ref. Status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
+                }
+            });
+        }
+
+        console.log(`Successfully updated build number to ${nextBuildNumber}`);
+
+        //Setting the output and a environment variable to new build number...
+        fs.writeFileSync(process.env.GITHUB_OUTPUT, `build_number=${nextBuildNumber}`);
+        fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${nextBuildNumber}`);
+
+        //Save to file so it can be used for next jobs...
+        fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());
+
+        //Cleanup
+        if (nrTags && deletePreviousTag) {
+            console.log(`Deleting ${nrTags.length} older build counters...`);
+
+            for (let nrTag of nrTags) {
+                request('DELETE', `/repos/${env.GITHUB_REPOSITORY}/git/${nrTag.ref}`, null, (err, status, result) => {
+                    if (status !== 204 || err) {
+                        console.warn(`Failed to delete ref ${nrTag.ref}, status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
+                    } else {
+                        console.log(`Deleted ${nrTag.ref}`);
+                    }
+                });
+            }
+        } else if (nrTags && !deletePreviousTag) {
+            console.log('Skipping deletion of previous build-number tags as requested.');
+        }
     });
 }
 
 main();
-
-
-

--- a/main.js
+++ b/main.js
@@ -60,6 +60,35 @@ function request(method, path, data, callback) {
 }
 
 
+function saveBuildNumber(nextBuildNumber, nrTags, deletePreviousTag) {
+    console.log(`Successfully updated build number to ${nextBuildNumber}`);
+
+    //Setting the output and a environment variable to new build number...
+    fs.writeFileSync(process.env.GITHUB_OUTPUT, `build_number=${nextBuildNumber}`);
+    fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${nextBuildNumber}`);
+
+    //Save to file so it can be used for next jobs...
+    fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());
+
+    //Cleanup
+    if (nrTags && deletePreviousTag) {
+        console.log(`Deleting ${nrTags.length} older build counters...`);
+
+        for (let nrTag of nrTags) {
+            request('DELETE', `/repos/${env.GITHUB_REPOSITORY}/git/${nrTag.ref}`, null, (err, status, result) => {
+                if (status !== 204 || err) {
+                    console.warn(`Failed to delete ref ${nrTag.ref}, status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
+                } else {
+                    console.log(`Deleted ${nrTag.ref}`);
+                }
+            });
+        }
+    } else if (nrTags && !deletePreviousTag) {
+        console.log('Skipping deletion of previous build-number tags as requested.');
+    }
+}
+
+
 function main() {
 
     const path = 'BUILD_NUMBER/BUILD_NUMBER';
@@ -151,6 +180,7 @@ function main() {
                         return;
                     }
 
+                    saveBuildNumber(nextBuildNumber, nrTags, deletePreviousTag);
                 });
             });
         } else {
@@ -163,33 +193,9 @@ function main() {
                 if (status !== 201 || err) {
                     fail(`Failed to create new build-number ref. Status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
                 }
+
+                saveBuildNumber(nextBuildNumber, nrTags, deletePreviousTag);
             });
-        }
-
-        console.log(`Successfully updated build number to ${nextBuildNumber}`);
-
-        //Setting the output and a environment variable to new build number...
-        fs.writeFileSync(process.env.GITHUB_OUTPUT, `build_number=${nextBuildNumber}`);
-        fs.writeFileSync(process.env.GITHUB_ENV, `BUILD_NUMBER=${nextBuildNumber}`);
-
-        //Save to file so it can be used for next jobs...
-        fs.writeFileSync('BUILD_NUMBER', nextBuildNumber.toString());
-
-        //Cleanup
-        if (nrTags && deletePreviousTag) {
-            console.log(`Deleting ${nrTags.length} older build counters...`);
-
-            for (let nrTag of nrTags) {
-                request('DELETE', `/repos/${env.GITHUB_REPOSITORY}/git/${nrTag.ref}`, null, (err, status, result) => {
-                    if (status !== 204 || err) {
-                        console.warn(`Failed to delete ref ${nrTag.ref}, status: ${status}, err: ${err}, result: ${JSON.stringify(result)}`);
-                    } else {
-                        console.log(`Deleted ${nrTag.ref}`);
-                    }
-                });
-            }
-        } else if (nrTags && !deletePreviousTag) {
-            console.log('Skipping deletion of previous build-number tags as requested.');
         }
     });
 }

--- a/tests/helpers/child_runner.js
+++ b/tests/helpers/child_runner.js
@@ -126,6 +126,9 @@ if (inputs.prefix !== undefined) process.env.INPUT_PREFIX = inputs.prefix;
 if (inputs.delete_previous_tag !== undefined) {
     process.env.INPUT_DELETE_PREVIOUS_TAG = String(inputs.delete_previous_tag);
 }
+if (inputs.annotated_tag !== undefined) {
+    process.env.INPUT_ANNOTATED_TAG = String(inputs.annotated_tag);
+}
 
 try {
     require(actionMain);

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -27,6 +27,20 @@ test('existing tags with default delete behavior: increments and deletes old ref
     assert.equal(deletes.length, 3);
 });
 
+test('add annotated tags with default delete behavior: increments and deletes old refs', async () => {
+    const r = await runAction({ tags: 3, inputs: { annotated_tag: true }  });
+    assert.equal(r.exit_code, null);
+    assert.equal(r.build_number, 4);
+    const posts = r.http_calls.filter((c) => c.method === 'POST');
+    assert.equal(posts.length, 2);
+    assert.ok(posts[0].path.includes('/git/tags'));
+    assert.ok(posts[0].body.includes('"message":"Build number 4"'));
+    assert.ok(posts[1].path.includes('/git/refs'));
+    assert.ok(posts[1].body.includes('refs/tags/build-number-4'));
+    const deletes = r.http_calls.filter((c) => c.method === 'DELETE');
+    assert.equal(deletes.length, 3);
+});
+
 test('delete_previous_tag=false: increments without deleting old refs', async () => {
     const r = await runAction({ tags: 3, inputs: { delete_previous_tag: false } });
     assert.equal(r.exit_code, null);


### PR DESCRIPTION
Support creating build-number tags as annotated tags when annotated_tag is enabled, while preserving the existing lightweight tag behavior by default. Document the new input and extend tests and helpers to cover annotated tag creation with existing cleanup behavior. This PR addresses Issue #20.

If this new option is not used (the default is lightweight tags), then code runs as before.

Updated README to mention new option, and added new unit test for annotated tag.