### PR TITLE
ci: run integration tests on fork PRs via safe-to-test label

### DIFF
--- a/.github/workflows/integration-fork.yml
+++ b/.github/workflows/integration-fork.yml
@@ -1,0 +1,120 @@
+# Integration tests for pull requests from forks.
+#
+# Fork PRs triggered via `pull_request` receive a read-only GITHUB_TOKEN,
+# so integration tests that create tag refs fail with 403. This workflow
+# uses `pull_request_target` (which runs with a write-capable token) but
+# is gated behind the `safe-to-test` label, which a maintainer applies
+# only AFTER reviewing the PR diff.
+#
+# Security model:
+#   - Runs only when the `safe-to-test` label is applied (types: [labeled]).
+#   - A companion workflow removes the label whenever new commits are
+#     pushed, so re-review is required before tests run again.
+#   - Job permissions are scoped to `contents: write` only.
+#   - The PR head is checked out explicitly and pinned to the labeled SHA.
+name: Integration (fork PRs)
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions: {}
+
+concurrency:
+  group: integration-fork-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  integration:
+    if: github.event.label.name == 'safe-to-test'
+    name: integration (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - { os: ubuntu-latest,  name: ubuntu,    delete_previous_tag: true  }
+          - { os: windows-latest, name: windows,   delete_previous_tag: true  }
+          - { os: ubuntu-latest,  name: no-delete, delete_previous_tag: false }
+    env:
+      TAG_PREFIX: ci-fork-${{ matrix.name }}-${{ github.run_id }}-${{ github.run_attempt }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v6
+      with:
+        # Pin to the exact SHA that carried the label. Do NOT check out
+        # a mutable ref here; the PR branch could be force-pushed after
+        # the label is applied.
+        ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
+
+    - name: First invocation
+      id: first
+      uses: ./
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: ${{ env.TAG_PREFIX }}
+        delete_previous_tag: ${{ matrix.delete_previous_tag }}
+
+    - name: Assert first invocation produced build_number=1 and created the tag
+      run: |
+        if [[ "${{ steps.first.outputs.build_number }}" != "1" ]]; then
+          echo "::error::Expected build_number=1, got '${{ steps.first.outputs.build_number }}'"
+          exit 1
+        fi
+        if [[ "$BUILD_NUMBER" != "${{ steps.first.outputs.build_number }}" ]]; then
+          echo "::error::BUILD_NUMBER env var does not match step output"
+          exit 1
+        fi
+        if ! gh api "repos/${{ github.repository }}/git/refs/tags/${TAG_PREFIX}-build-number-1" > /dev/null 2>&1; then
+          echo "::error::Tag ${TAG_PREFIX}-build-number-1 was not created"
+          exit 1
+        fi
+
+    - name: Second invocation
+      id: second
+      uses: ./
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        prefix: ${{ env.TAG_PREFIX }}
+        delete_previous_tag: ${{ matrix.delete_previous_tag }}
+
+    - name: Assert second invocation incremented and respected delete_previous_tag
+      run: |
+        if [[ "${{ steps.second.outputs.build_number }}" != "2" ]]; then
+          echo "::error::Expected build_number=2, got '${{ steps.second.outputs.build_number }}'"
+          exit 1
+        fi
+        # Brief pause for ref deletions to propagate through GitHub's API
+        sleep 2
+        if gh api "repos/${{ github.repository }}/git/refs/tags/${TAG_PREFIX}-build-number-1" > /dev/null 2>&1; then
+          first_tag_exists=true
+        else
+          first_tag_exists=false
+        fi
+        if [[ "${{ matrix.delete_previous_tag }}" == "true" && "$first_tag_exists" == "true" ]]; then
+          echo "::error::Tag ${TAG_PREFIX}-build-number-1 should have been deleted but still exists"
+          exit 1
+        fi
+        if [[ "${{ matrix.delete_previous_tag }}" == "false" && "$first_tag_exists" == "false" ]]; then
+          echo "::error::Tag ${TAG_PREFIX}-build-number-1 should still exist with delete_previous_tag=false"
+          exit 1
+        fi
+
+    - name: Cleanup tags created by this run
+      if: always()
+      run: |
+        # matching-refs returns refs whose names start with the given prefix
+        gh api "repos/${{ github.repository }}/git/matching-refs/tags/${TAG_PREFIX}-build-number-" \
+          --jq '.[].ref' \
+          | while read -r ref; do
+              echo "Deleting $ref"
+              gh api -X DELETE "repos/${{ github.repository }}/git/${ref}" || true
+            done

--- a/.github/workflows/remove-safe-to-test-label.yml
+++ b/.github/workflows/remove-safe-to-test-label.yml
@@ -1,0 +1,39 @@
+# Removes the `safe-to-test` label whenever a PR receives new commits.
+#
+# This closes the approve-then-swap loophole: a contributor cannot get
+# the label applied to a reviewed commit and then push malicious code
+# that runs with a write token. Every new push requires a maintainer to
+# re-review and re-apply the label.
+#
+# NOTE: This workflow runs the base branch's code only (no PR checkout),
+# so it is safe under pull_request_target.
+name: Remove safe-to-test label
+
+on:
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove-label:
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              name: 'safe-to-test'
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: 'New commits were pushed, so the `safe-to-test` label was removed. A maintainer needs to re-review the changes and re-apply the label to run integration tests.'
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
   # github.run_id + run_attempt so concurrent CI runs never collide, and a
   # final always-on cleanup step deletes every tag created by the run.
   integration:
+    # Fork PRs get a read-only GITHUB_TOKEN, so this job would always fail
+    # with 403. Fork PRs are covered by the label-gated integration-fork
+    # workflow instead.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     name: integration (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
## Problem

Integration tests fail on every fork PR (most recently #25). The `pull_request` event gives fork runs a read-only `GITHUB_TOKEN`, so any test that creates tag refs dies with `403 Resource not accessible by integration`. This is a CI limitation, not a fault in contributors' code — but it leaves fork PRs permanently red and their changes untested against real git refs.

## Solution

Label-gated integration tests on `pull_request_target`, which runs with a write-capable token:

1. **`integration-fork.yml`** — runs the same dogfood integration matrix as `test.yml` (unique per-run `TAG_PREFIX`, `delete_previous_tag` variants, exact build-number assertions, always-on tag cleanup), but only when a maintainer applies the `safe-to-test` label.
2. **`remove-safe-to-test-label.yml`** — strips the label whenever new commits are pushed to a labeled PR and comments that re-review is needed.
3. **`test.yml`** — the existing integration job now skips fork `pull_request` runs (instead of red-failing on a guaranteed 403). Unit tests still run on all PRs.

## Security model

`pull_request_target` with PR code checkout is dangerous by default, so the workflow layers these controls:

- **Label gate**: triggers only on `types: [labeled]` with `if: github.event.label.name == 'safe-to-test'` — nothing runs until a maintainer has reviewed the diff and applied the label.
- **SHA pinning**: checkout uses `github.event.pull_request.head.sha`, the exact commit that carried the label — a force-push after labeling cannot swap in unreviewed code.
- **Auto-unlabel on push**: the companion workflow removes the label on `synchronize`, so every new commit requires fresh maintainer review before tests run again.
- **Scoped permissions**: top-level `permissions: {}`; the job gets `contents: write` only. `persist-credentials: false` keeps the token out of the checkout's git config.
- **Serialized matrix**: `max-parallel: 1` plus a per-PR concurrency group, since matrix runs share the repo's tag namespace.

## Maintainer flow

1. Fork PR arrives; unit tests run automatically, integration is skipped.
2. Review the diff for anything that could abuse a write token.
3. Apply the `safe-to-test` label → integration tests run against the labeled SHA.
4. If the author pushes more commits, the label is removed automatically — re-review and re-apply.

## Post-merge setup (one-time)

- Create the label: `gh label create safe-to-test --description "Maintainer-approved to run integration tests" --color 0E8A16`
- Optionally apply it to #25 to re-run its integration tests.
